### PR TITLE
rinvex master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+  open-pull-requests-limit: 10
+  target-branch: develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: bionic
 language: php
 
 php:
-- 7.4
 - 8.0
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 
 php:
 - 8.0
+- 8.1
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](CONTRIBUTING.md).
 
 
+## [v6.0.0] - 2021-08-22
+- Drop PHP v7 support, and upgrade rinvex package dependencies to next major version
+- Update composer dependencies
+- Merge rules instead of resetting, to allow adequate model override
+- Fix constructor initialization order (fill attributes should come next after merging fillables & rules)
+- Drop old MySQL versions support that doesn't support json columns
+- Upgrade to GitHub-native Dependabot
+
 ## [v5.0.3] - 2021-03-15
 - Changes in doc to reflect new ofSubscriber breaking change
 - Utilize `SoftDeletes` functionality (fix #142)
@@ -147,6 +155,7 @@ This project adheres to [Semantic Versioning](CONTRIBUTING.md).
 ## v0.0.1 - 2017-06-29
 - Tag first release
 
+[v6.0.0]: https://github.com/rinvex/laravel-subscriptions/compare/v5.0.3...v6.0.0
 [v5.0.3]: https://github.com/rinvex/laravel-subscriptions/compare/v5.0.2...v5.0.3
 [v5.0.2]: https://github.com/rinvex/laravel-subscriptions/compare/v5.0.1...v5.0.2
 [v5.0.1]: https://github.com/rinvex/laravel-subscriptions/compare/v5.0.0...v5.0.1

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "rinvex/laravel-support": "^5.0.0",
         "spatie/eloquent-sortable": "^3.7.0",
         "spatie/laravel-sluggable": "^3.0.0",
-        "spatie/laravel-translatable": "^4.2.0"
+        "spatie/laravel-translatable": "^5.0.0"
     },
     "require-dev": {
         "codedungeon/phpunit-result-printer": "^0.30.0",

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,11 @@
         }
     ],
     "require": {
-        "php": "^7.4.0 || ^8.0.0",
+        "php": "^8.0.0",
         "illuminate/console": "^8.0.0 || ^9.0.0",
         "illuminate/database": "^8.0.0 || ^9.0.0",
         "illuminate/support": "^8.0.0 || ^9.0.0",
-        "rinvex/laravel-support": "^5.0.0",
+        "rinvex/laravel-support": "^6.0.0",
         "spatie/eloquent-sortable": "^4.0.0",
         "spatie/laravel-sluggable": "^3.0.0",
         "spatie/laravel-translatable": "^5.0.0"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "illuminate/database": "^8.0.0 || ^9.0.0",
         "illuminate/support": "^8.0.0 || ^9.0.0",
         "rinvex/laravel-support": "^5.0.0",
-        "spatie/eloquent-sortable": "^3.7.0",
+        "spatie/eloquent-sortable": "^4.0.0",
         "spatie/laravel-sluggable": "^3.0.0",
         "spatie/laravel-translatable": "^5.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "illuminate/support": "^8.0.0 || ^9.0.0",
         "rinvex/laravel-support": "^5.0.0",
         "spatie/eloquent-sortable": "^3.7.0",
-        "spatie/laravel-sluggable": "^2.2.0",
+        "spatie/laravel-sluggable": "^3.0.0",
         "spatie/laravel-translatable": "^4.2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "spatie/laravel-translatable": "^5.0.0"
     },
     "require-dev": {
-        "codedungeon/phpunit-result-printer": "^0.30.0",
+        "codedungeon/phpunit-result-printer": "^0.31.0",
         "illuminate/container": "^8.0.0 || ^9.0.0",
         "phpunit/phpunit": "^9.5.0"
     },

--- a/database/migrations/2020_01_01_000001_create_plans_table.php
+++ b/database/migrations/2020_01_01_000001_create_plans_table.php
@@ -18,8 +18,8 @@ class CreatePlansTable extends Migration
             // Columns
             $table->increments('id');
             $table->string('slug');
-            $table->{$this->jsonable()}('name');
-            $table->{$this->jsonable()}('description')->nullable();
+            $table->json('name');
+            $table->json('description')->nullable();
             $table->boolean('is_active')->default(true);
             $table->decimal('price')->default('0.00');
             $table->decimal('signup_fee')->default('0.00');
@@ -51,19 +51,5 @@ class CreatePlansTable extends Migration
     public function down(): void
     {
         Schema::dropIfExists(config('rinvex.subscriptions.tables.plans'));
-    }
-
-    /**
-     * Get jsonable column data type.
-     *
-     * @return string
-     */
-    protected function jsonable(): string
-    {
-        $driverName = DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $dbVersion = DB::connection()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
-        $isOldVersion = version_compare($dbVersion, '5.7.8', 'lt');
-
-        return $driverName === 'mysql' && $isOldVersion ? 'text' : 'json';
     }
 }

--- a/database/migrations/2020_01_01_000002_create_plan_features_table.php
+++ b/database/migrations/2020_01_01_000002_create_plan_features_table.php
@@ -19,8 +19,8 @@ class CreatePlanFeaturesTable extends Migration
             $table->increments('id');
             $table->integer('plan_id')->unsigned();
             $table->string('slug');
-            $table->{$this->jsonable()}('name');
-            $table->{$this->jsonable()}('description')->nullable();
+            $table->json('name');
+            $table->json('description')->nullable();
             $table->string('value');
             $table->smallInteger('resettable_period')->unsigned()->default(0);
             $table->string('resettable_interval')->default('month');
@@ -43,19 +43,5 @@ class CreatePlanFeaturesTable extends Migration
     public function down(): void
     {
         Schema::dropIfExists(config('rinvex.subscriptions.tables.plan_features'));
-    }
-
-    /**
-     * Get jsonable column data type.
-     *
-     * @return string
-     */
-    protected function jsonable(): string
-    {
-        $driverName = DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $dbVersion = DB::connection()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
-        $isOldVersion = version_compare($dbVersion, '5.7.8', 'lt');
-
-        return $driverName === 'mysql' && $isOldVersion ? 'text' : 'json';
     }
 }

--- a/database/migrations/2020_01_01_000003_create_plan_subscriptions_table.php
+++ b/database/migrations/2020_01_01_000003_create_plan_subscriptions_table.php
@@ -19,8 +19,8 @@ class CreatePlanSubscriptionsTable extends Migration
             $table->morphs('subscriber');
             $table->integer('plan_id')->unsigned();
             $table->string('slug');
-            $table->{$this->jsonable()}('name');
-            $table->{$this->jsonable()}('description')->nullable();
+            $table->json('name');
+            $table->json('description')->nullable();
             $table->dateTime('trial_ends_at')->nullable();
             $table->dateTime('starts_at')->nullable();
             $table->dateTime('ends_at')->nullable();
@@ -45,19 +45,5 @@ class CreatePlanSubscriptionsTable extends Migration
     public function down(): void
     {
         Schema::dropIfExists(config('rinvex.subscriptions.tables.plan_subscriptions'));
-    }
-
-    /**
-     * Get jsonable column data type.
-     *
-     * @return string
-     */
-    protected function jsonable(): string
-    {
-        $driverName = DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
-        $dbVersion = DB::connection()->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION);
-        $isOldVersion = version_compare($dbVersion, '5.7.8', 'lt');
-
-        return $driverName === 'mysql' && $isOldVersion ? 'text' : 'json';
     }
 }

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -171,8 +171,6 @@ class Plan extends Model implements Sortable
      */
     public function __construct(array $attributes = [])
     {
-        parent::__construct($attributes);
-
         $this->setTable(config('rinvex.subscriptions.tables.plans'));
         $this->setRules([
             'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plans').',slug',
@@ -194,6 +192,8 @@ class Plan extends Model implements Sortable
             'prorate_extend_due' => 'nullable|integer|max:150',
             'active_subscribers_limit' => 'nullable|integer|max:100000',
         ]);
+
+        parent::__construct($attributes);
     }
 
     /**

--- a/src/Models/Plan.php
+++ b/src/Models/Plan.php
@@ -172,7 +172,7 @@ class Plan extends Model implements Sortable
     public function __construct(array $attributes = [])
     {
         $this->setTable(config('rinvex.subscriptions.tables.plans'));
-        $this->setRules([
+        $this->mergeRules([
             'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plans').',slug',
             'name' => 'required|string|strip_tags|max:150',
             'description' => 'nullable|string|max:32768',

--- a/src/Models/PlanFeature.php
+++ b/src/Models/PlanFeature.php
@@ -137,7 +137,7 @@ class PlanFeature extends Model implements Sortable
     public function __construct(array $attributes = [])
     {
         $this->setTable(config('rinvex.subscriptions.tables.plan_features'));
-        $this->setRules([
+        $this->mergeRules([
             'plan_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plans').',id',
             'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plan_features').',slug',
             'name' => 'required|string|strip_tags|max:150',

--- a/src/Models/PlanFeature.php
+++ b/src/Models/PlanFeature.php
@@ -136,8 +136,6 @@ class PlanFeature extends Model implements Sortable
      */
     public function __construct(array $attributes = [])
     {
-        parent::__construct($attributes);
-
         $this->setTable(config('rinvex.subscriptions.tables.plan_features'));
         $this->setRules([
             'plan_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plans').',id',
@@ -149,6 +147,8 @@ class PlanFeature extends Model implements Sortable
             'resettable_interval' => 'sometimes|in:hour,day,week,month',
             'sort_order' => 'nullable|integer|max:100000',
         ]);
+
+        parent::__construct($attributes);
     }
 
     /**

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -146,7 +146,7 @@ class PlanSubscription extends Model
     public function __construct(array $attributes = [])
     {
         $this->setTable(config('rinvex.subscriptions.tables.plan_subscriptions'));
-        $this->setRules([
+        $this->mergeRules([
             'name' => 'required|string|strip_tags|max:150',
             'description' => 'nullable|string|max:32768',
             'slug' => 'required|alpha_dash|max:150|unique:'.config('rinvex.subscriptions.tables.plan_subscriptions').',slug',

--- a/src/Models/PlanSubscription.php
+++ b/src/Models/PlanSubscription.php
@@ -145,8 +145,6 @@ class PlanSubscription extends Model
      */
     public function __construct(array $attributes = [])
     {
-        parent::__construct($attributes);
-
         $this->setTable(config('rinvex.subscriptions.tables.plan_subscriptions'));
         $this->setRules([
             'name' => 'required|string|strip_tags|max:150',
@@ -161,6 +159,8 @@ class PlanSubscription extends Model
             'cancels_at' => 'nullable|date',
             'canceled_at' => 'nullable|date',
         ]);
+
+        parent::__construct($attributes);
     }
 
     /**

--- a/src/Models/PlanSubscriptionUsage.php
+++ b/src/Models/PlanSubscriptionUsage.php
@@ -92,8 +92,6 @@ class PlanSubscriptionUsage extends Model
      */
     public function __construct(array $attributes = [])
     {
-        parent::__construct($attributes);
-
         $this->setTable(config('rinvex.subscriptions.tables.plan_subscription_usage'));
         $this->setRules([
             'subscription_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plan_subscriptions').',id',
@@ -101,6 +99,8 @@ class PlanSubscriptionUsage extends Model
             'used' => 'required|integer',
             'valid_until' => 'nullable|date',
         ]);
+
+        parent::__construct($attributes);
     }
 
     /**

--- a/src/Models/PlanSubscriptionUsage.php
+++ b/src/Models/PlanSubscriptionUsage.php
@@ -93,7 +93,7 @@ class PlanSubscriptionUsage extends Model
     public function __construct(array $attributes = [])
     {
         $this->setTable(config('rinvex.subscriptions.tables.plan_subscription_usage'));
-        $this->setRules([
+        $this->mergeRules([
             'subscription_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plan_subscriptions').',id',
             'feature_id' => 'required|integer|exists:'.config('rinvex.subscriptions.tables.plan_features').',id',
             'used' => 'required|integer',


### PR DESCRIPTION
- Upgrade to GitHub-native Dependabot
- Drop old MySQL versions support that doesn't support json columns
- Fix constructor initialization order (fill attributes should come next after merging fillables & rules)
- Update spatie/laravel-sluggable composer package to v3.0.0
- Update spatie/laravel-translatable composer package to v5.0.0
- Update spatie/eloquent-sortable composer package to v4.0.0
- Merge rules instead of resetting, to allow adequate model override
- Update composer dependencies
- Drop PHP v7 support, and upgrade rinvex package dependencies to next major version
- Drop PHP v7 support, and upgrade rinvex package dependencies to next major version
- Bump version
